### PR TITLE
Change to precise64-10g box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,10 +5,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
+  config.vm.box = "precise64-10g"
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box_url = "https://dl.dropboxusercontent.com/s/6osak6v3pnun72l/precise64-10g.box"
 
   # Set the name
   config.vm.define "vagrant-dryad"


### PR DESCRIPTION
The Vagrantfile now references a 10GB precise64 box.

I created this box by starting with the 80GB precise64 box at http://files.vagrantup.com/precise64.box.

I attached the VMDK to an Ubuntu VM, and shrank the filesystem using `resize2fs` and `lvreduce` (as mentioned here: http://blog.shadypixel.com/how-to-shrink-an-lvm-volume-safely/).

Then, I verified the vagrant vm booted up with the resized box, ran `vagrant package` to produce a .box file, and posted it to Dropbox.
