### PR TITLE
added synced_folder entries to Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 dryad-vagrant.sql
 ansible-dryad/group_vars/all
+sync/

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ In addition to passwords and Git repo addresses, software versions, file paths, 
 
 In addition to port forwarding, the contents of this directory (The one containing the Vagrantfile) are synchronized from your host computer to the virtual machine's `/vagrant` directory. Additional synchronized directories can be added to the Vagrantfile. For example, the `dryad-bootstrap.sql` file that installs necessary content into the database is stored here, and used by the VM during installation.
 
+When VirtualBox is used as the VM provider, vagrant is configured to sync the guest system's "/opt/dryad" and "/home/vagrant/dryad-repo" directories to subdirectories of this directory's "sync/" subdirectory.
+
 ## Upgrading your VM
 
 As improvements are added to the vagrant/ansible configurations, you can incorporate the changes by merging in the latest changes from this repo, and running `vagrant provision`. Provisioning will bring your VM up to date without removing existing data or files. You may have to add new values to your `ansible-dryad/group_vars/all` file if they are required by newer versions of the ansible playbook, but the Vagrantfile will usually check for these important changes.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,6 +83,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Default value: false
   config.ssh.forward_agent = true
 
+  # sync VM directories with local ./sync directory
+  config.vm.synced_folder "sync/opt/dryad",  "/opt/dryad",  create: false
+  config.vm.synced_folder "sync/home/vagrant/dryad-repo",  "/home/vagrant/dryad-repo",  create: false
+
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
@@ -117,3 +121,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.host_key_checking = false
   end
 end
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,17 +83,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Default value: false
   config.ssh.forward_agent = true
 
-  # sync VM directories with local ./sync directory
-  config.vm.synced_folder "sync/opt/dryad",  "/opt/dryad",  create: false
-  config.vm.synced_folder "sync/home/vagrant/dryad-repo",  "/home/vagrant/dryad-repo",  create: false
-
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
   config.vm.provider "virtualbox" do |vb, override|
     # Use VBoxManage to customize the VM. For example to change memory:
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.memory = 1024
+    vb.cpus = 2
+    # sync VM directories with local ./sync directory
+    # config.vm.synced_folder "sync/opt/dryad",  "/opt/dryad",  create: false
+    # config.vm.synced_folder "sync/home/vagrant/dryad-repo",  "/home/vagrant/dryad-repo",  create: false
   end
   config.vm.provider :aws do |aws, override|
     override.vm.box = "dummy"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,9 +91,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Use VBoxManage to customize the VM. For example to change memory:
     vb.memory = 1024
     vb.cpus = 2
-    # sync VM directories with local ./sync directory
-    # config.vm.synced_folder "sync/opt/dryad",  "/opt/dryad",  create: false
-    # config.vm.synced_folder "sync/home/vagrant/dryad-repo",  "/home/vagrant/dryad-repo",  create: false
+    # sync VM guest directories with the local ./sync directory
+    # NOTE: the synced_folder configuration done here is meant to support 
+    # dryad development with a local VM hosting the dryad codebase and running
+    # the applicaiton. It is not done for the AWS provider because
+    # that provider type shares guest -> host only (not bidirectionally), which is 
+    # not useful for the expected development scenario.
+    # See https://github.com/mitchellh/vagrant-aws/blob/master/README.md#synced-folders
+    override.vm.synced_folder "sync/opt/dryad",  "/opt/dryad",  create: false
+    override.vm.synced_folder "sync/home/vagrant/dryad-repo",  "/home/vagrant/dryad-repo",  create: false
   end
   config.vm.provider :aws do |aws, override|
     override.vm.box = "dummy"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,10 +83,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Default value: false
   config.ssh.forward_agent = true
 
-  # sync VM directories with local ./sync directory
-  config.vm.synced_folder "sync/opt/dryad",  "/opt/dryad",  create: false
-  config.vm.synced_folder "sync/home/vagrant/dryad-repo",  "/home/vagrant/dryad-repo",  create: false
-
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,6 +83,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Default value: false
   config.ssh.forward_agent = true
 
+  # sync VM directories with local ./sync directory
+  config.vm.synced_folder "sync/opt/dryad",  "/opt/dryad",  create: false
+  config.vm.synced_folder "sync/home/vagrant/dryad-repo",  "/home/vagrant/dryad-repo",  create: false
+
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:


### PR DESCRIPTION
Added two config.vm.synced_folder entries to enable a couple of useful
guest directories to be available from the host system.

This config does not create any directories on the host or guest system,
so before 'vagrant up' is run, the host directories (./sync/...) must be
created. Vagrant warns and exits if the local directories are not present.