### PR TITLE
Prevent the VM from filling with useless backups

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/deploy_dryad.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/deploy_dryad.sh.j2
@@ -2,6 +2,7 @@
 
 set -e
 cd {{ dryad.repo_path }}/dspace/target/dspace-1.7.3-SNAPSHOT-build.dir/
+ant clean_backups -Doverwrite=true
 ant update -Doverwrite=true
 
 echo "Dryad has been deployed. Start tomcat with:"


### PR DESCRIPTION
With each build, remove the previous backup. The build will backup the
current installation, so one backup is always retained.

If the earlier (and mostly useless) backups are not removed, the VM
will eventually run out of disk space.
