### PR TITLE
Support for testing automatic release from blackout

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/install_dryad_test_database.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/install_dryad_test_database.sh.j2
@@ -35,7 +35,7 @@ if [ -d $DRYAD_TEST_DIR ]; then
   rm -rf "${DRYAD_TEST_DIR}"
 fi
 
-cp -r "${DRYAD_CODE_DIR}/test" "${DRYAD_TEST_DIR}"
+cp -L -r "${DRYAD_CODE_DIR}/test" "${DRYAD_TEST_DIR}"
 
 # Update the testing version of dspace.cfg with database credentials
 # Ansible provisioning installs password into .pgpass, so fish it out of there

--- a/ansible-dryad/roles/dryad_app/templates/install_dryad_test_database.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/install_dryad_test_database.sh.j2
@@ -25,6 +25,7 @@ psql < ${DRYAD_CODE_DIR}/dspace/etc/atmire-versioning-changes.sql
 psql < ${DRYAD_CODE_DIR}/dspace/etc/postgres/database_dryad_groups_collections.sql
 psql < ${DRYAD_CODE_DIR}/dspace/etc/postgres/database_dryad_registries.sql
 psql < ${DRYAD_CODE_DIR}/dspace/etc/postgres/dryad-rest-webapp.sql
+psql < ${DRYAD_CODE_DIR}/test/etc/postgres/test-system-curator.sql
 psql < ${DRYAD_CODE_DIR}/dspace/etc/postgres/update-sequences.sql
 
 # Copy test directory to local filesystem, outside of source repo, and owned by dryad user


### PR DESCRIPTION
Updates the test environment/database to support changes in https://github.com/datadryad/dryad-repo/pull/809