### PR TITLE
update test suffix

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
+++ b/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
@@ -22,7 +22,7 @@
         <default.doi.password>{{ dryad.doi.password }}</default.doi.password>
         <default.doi.prefix>10.5061</default.doi.prefix>
         <default.doi.testprefix>10.5072</default.doi.testprefix>
-        <default.doi.localpart.testsuffix>FK2.5061.dryad.</default.doi.localpart.testsuffix>
+        <default.doi.localpart.testsuffix>FK2dryad.</default.doi.localpart.testsuffix>
       	<default.doi.testmode>true</default.doi.testmode>
         <default.dryad.localize>true</default.dryad.localize>
         <default.doi.datacite.connected>false</default.doi.datacite.connected>


### PR DESCRIPTION
The doi.localpart.testsuffix needs to be updated in the VM.
NB: this will not update the test install version, as that comes from the dryad-repo/test/config/dspace.cfg file. That will be a separate pull request.

To test this fix: install a clean VM, then do a build/deploy. Nothing should break, but if you make a new package, it will have a doi starting with `10.5072/FK2dryad.xxxx`.