### PR TITLE
enhance test config for more involved tests

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/install_dryad_test_database.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/install_dryad_test_database.sh.j2
@@ -35,12 +35,20 @@ if [ -d $DRYAD_TEST_DIR ]; then
   rm -rf "${DRYAD_TEST_DIR}"
 fi
 
-cp -L -r "${DRYAD_CODE_DIR}/test" "${DRYAD_TEST_DIR}"
+cp -L -p -r "${DRYAD_CODE_DIR}/test" "${DRYAD_TEST_DIR}"
+
+# These are needed somehow by bagit ingest tests
+cp -p -r "${DRYAD_CODE_DIR}/dspace/config/crosswalks" "${DRYAD_TEST_DIR}/config/"
+cp -p -r "${DRYAD_CODE_DIR}/dspace/config/dspace-solr-search.cfg" "${DRYAD_TEST_DIR}/config/"
 
 # Update the testing version of dspace.cfg with database credentials
 # Ansible provisioning installs password into .pgpass, so fish it out of there
 
-sed -i "s|db.password =.*|db.password = ${PGPASSWORD}|g" "${DRYAD_TEST_DIR}/config/dspace.cfg"
-sed -i "s|db.username =.*|db.username = ${PGUSER}|g" "${DRYAD_TEST_DIR}/config/dspace.cfg"
-sed -i "s|db.url =.*|db.url = jdbc:postgresql://${PGHOST}:${PGPORT}/${PGDATABASE}|g" "${DRYAD_TEST_DIR}/config/dspace.cfg"
-sed -i "s|dspace.dir = .*|dspace.dir = ${DRYAD_TEST_DIR}|g" "${DRYAD_TEST_DIR}/config/dspace.cfg"
+cat "${DRYAD_CODE_DIR}/dspace/config/dspace.cfg" \
+  | sed "s|db.password =.*|db.password = ${PGPASSWORD}|g" \
+  | sed "s|db.username =.*|db.username = ${PGUSER}|g" \
+  | sed "s|db.url =.*|db.url = jdbc:postgresql://${PGHOST}:${PGPORT}/${PGDATABASE}|g" \
+  | sed "s|dspace.dir = .*|dspace.dir = ${DRYAD_TEST_DIR}|g" \
+  | sed "s|doi.service.testmode= .*|doi.service.testmode= true|g" \
+  | sed "s|doi.datacite.connected = .*|doi.datacite.connected = false|g" \
+  >"${DRYAD_TEST_DIR}/config/dspace.cfg"


### PR DESCRIPTION
These are changes that I needed in order to run unit tests for bagit ingestion, which includes doing a crosswalk and therefore makes strong demands on dspace.cfg. I don't know if all these sed commands is the right way to accomplish these changes, but that's how it was done before and it works for me.

I checked test/config/dspace.cfg to make sure that everything set there is also set in dspace/config/dspace.cfg, and it is, so would be OK to jettison test/config/dspace.cfg.

I've tested install_dryad_test_database.sh in an older vagrant-dryad installation, then merged the changes into the latest .j2 file, but have not done a complete test creating a VM and so on to make absolutely sure the commit is right.