### PR TITLE
redirect codehaus to maven central

### DIFF
--- a/ansible-dryad/roles/dryad_app/tasks/dryad_code.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_code.yml
@@ -96,3 +96,6 @@
 
 - name: Regenerated motd for next login
   shell: run-parts /etc/update-motd.d/ > /var/run/motd
+
+- name: Redirect codehaus domain
+  shell: echo "23.235.47.209 repository.codehaus.org" >> /etc/hosts


### PR DESCRIPTION
Codehaus is dead. Redirect references to repository.codehaus.org to repo1.maven.org’s IP. See https://atmire.com/tickets-nescent2/view-ticket?id=2528 for more details.