### PR TITLE
add ubuntu packer template for building local image

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ This command takes a while - it's downloading a base virtual machine, installing
 
 Sometimes provisioning fails with `fatal: [x.x.x.x] => SSH encountered an unknown error during the connection.`.  In this case simply retry with `vagrant provision`
 
+### Alternative base image
+
+An alternative to using the default image indicated in the Vagrantfile (precise64-10g.box) is to build an image locally. See the README.md file in the directory 'packer-templates' for steps to build and use a locally built image.
+
+Note that the default (precise64-10g) image is unable to support storage of over 10Gb, which is exceeded during import of the production database. Replacing the default image, by building an alternative locally or using another base URL, is required in that case.
+
 ## Accessing the Virtual Machine
 
 After the machine has been created/provisioned successfully, you can log in with

--- a/packer-templates/README.md
+++ b/packer-templates/README.md
@@ -1,0 +1,36 @@
+
+This directory contains Ubuntu Vagrant box templates to use in place of the
+default `vagrant-dryad` box,
+[precise64-10g](http://datadryad.org/downloads/precise64-10g.box), if a
+disk larger than 10g is needed.
+
+The script `./ubuntu-12.04/vagrant-box-dryad.sh` will build a 64-bit Ubuntu
+12.04 Vagrant box and install it to the local machine as `dryad-ubuntu-12-04`.
+
+The new box can be used to replace the default Vagrant box in the Vagrantfile: 
+
+```
+#config.vm.box = "precise64-10g"
+config.vm.box = "dryad-ubuntu-12-04"
+```
+
+Once started, the `dryad-ubuntu-12-04` machine's (dynamically allocated) hard disk
+will have a virtual size of 40 GB. This is currently (2016/02) necessary when 
+importing the production Dryad database into the Vagrant hosted environment.
+
+#Installation
+
+Packer is available by download from http://www.packer.io/downloads.html or
+using a package manager, e.g.:
+
+```
+brew install packer
+```
+
+#Credits
+
+These templates were taken from:
+
+https://github.com/shiguredo/packer-templates
+
+

--- a/packer-templates/ubuntu-12.04/http/preseed.cfg
+++ b/packer-templates/ubuntu-12.04/http/preseed.cfg
@@ -1,0 +1,38 @@
+debconf debconf/frontend select Noninteractive
+choose-mirror-bin mirror/http/proxy string
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+
+# Default user
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i passwd/username string vagrant
+
+# Minimum packages (see postinstall.sh)
+d-i pkgsel/include string openssh-server
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select none
+
+d-i time/zone string UTC
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+tasksel tasksel/first multiselect standard, server
+

--- a/packer-templates/ubuntu-12.04/scripts/base.sh
+++ b/packer-templates/ubuntu-12.04/scripts/base.sh
@@ -1,0 +1,9 @@
+rm /var/lib/apt/lists/*
+apt-get update
+apt-get -y upgrade
+apt-get -y install linux-headers-$(uname -r)
+
+sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
+sed -i -e 's/%sudo  ALL=(ALL:ALL) ALL/%sudo  ALL=NOPASSWD:ALL/g' /etc/sudoers
+
+echo "UseDNS no" >> /etc/ssh/sshd_config

--- a/packer-templates/ubuntu-12.04/scripts/cleanup.sh
+++ b/packer-templates/ubuntu-12.04/scripts/cleanup.sh
@@ -1,0 +1,15 @@
+apt-get -y autoremove
+apt-get -y clean
+
+echo "cleaning up guest additions"
+rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
+
+echo "cleaning up dhcp leases"
+rm /var/lib/dhcp/*
+
+echo "cleaning up udev rules"
+rm /etc/udev/rules.d/70-persistent-net.rules
+mkdir /etc/udev/rules.d/70-persistent-net.rules
+rm -rf /dev/.udev/
+rm /lib/udev/rules.d/75-persistent-net-generator.rules
+

--- a/packer-templates/ubuntu-12.04/scripts/vagrant.sh
+++ b/packer-templates/ubuntu-12.04/scripts/vagrant.sh
@@ -1,0 +1,8 @@
+date > /etc/vagrant_box_build_time
+
+mkdir /home/vagrant/.ssh
+wget --no-check-certificate \
+    'https://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' \
+    -O /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh

--- a/packer-templates/ubuntu-12.04/scripts/virtualbox.sh
+++ b/packer-templates/ubuntu-12.04/scripts/virtualbox.sh
@@ -1,0 +1,9 @@
+apt-get -y install dkms
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+cd /tmp
+wget http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso
+mount -o loop VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+
+rm VBoxGuestAdditions_$VBOX_VERSION.iso

--- a/packer-templates/ubuntu-12.04/scripts/zerodisk.sh
+++ b/packer-templates/ubuntu-12.04/scripts/zerodisk.sh
@@ -1,0 +1,2 @@
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/packer-templates/ubuntu-12.04/template.json
+++ b/packer-templates/ubuntu-12.04/template.json
@@ -1,0 +1,127 @@
+{
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'",
+      "override": {
+        "virtualbox-iso": {
+          "scripts": [
+            "scripts/base.sh",
+            "scripts/vagrant.sh",
+            "scripts/virtualbox.sh",
+            "scripts/cleanup.sh",
+            "scripts/zerodisk.sh"
+          ]
+        },
+        "vmware-iso": {
+          "scripts": [
+            "scripts/base.sh",
+            "scripts/vagrant.sh",
+            "scripts/cleanup.sh",
+            "scripts/zerodisk.sh"
+          ]
+        }
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "override": {
+        "virtualbox": {
+          "output": "ubuntu-12-04-x64-virtualbox.box"
+        },
+        "vmware": {
+          "output": "ubuntu-12-04-x64-vmware.box"
+        }
+      }
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debian-installer=en_US<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US<wait>",
+        " netcfg/get_hostname=ubuntu-1204<wait>",
+        " netcfg/get_domain=vagrantup.com<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "Ubuntu_64",
+      "http_directory": "http",
+      "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso",
+      "iso_checksum": "af224223de99e2a730b67d7785b657f549be0d63221188e105445f75fb8305c9",
+      "iso_checksum_type": "sha256",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ]
+    },
+    {
+      "type": "vmware-iso",
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debian-installer=en_US<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US<wait>",
+        " netcfg/get_hostname=ubuntu-1204<wait>",
+        " netcfg/get_domain=vagrantup.com<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "linux",
+      "http_directory": "http",
+      "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso",
+      "iso_checksum": "af224223de99e2a730b67d7785b657f549be0d63221188e105445f75fb8305c9",
+      "iso_checksum_type": "sha256",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+      "vmx_data": {
+        "memsize": "512",
+        "numvcpus": "1",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ]
+}

--- a/packer-templates/ubuntu-12.04/vagrant-box-dryad.sh
+++ b/packer-templates/ubuntu-12.04/vagrant-box-dryad.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+#
+
+packer build -only=virtualbox-iso -parallel=true template.json
+vagrant box add ubuntu-12-04-x64-virtualbox.box --name dryad-ubuntu-12-04
+


### PR DESCRIPTION
This script and config builds a VirtualBox-compatible box that supports importing a dump of the production DB. Attempting to import the DB with the default vagrant-dryad box leads to virtual disk storage issues that cause the import to fail.
This has been tested out on my OSX system.