### PR TITLE
Add journal-types registry to install_dryad_database script

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/install_dryad_database.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/install_dryad_database.sh.j2
@@ -39,7 +39,8 @@ echo "Installing metadata schemas"
 {{ dryad.install_dir }}/bin/dsrun org.dspace.administer.MetadataImporter -f {{ dryad.install_dir }}/config/registries/dryad-types.xml
 {{ dryad.install_dir }}/bin/dsrun org.dspace.administer.MetadataImporter -f {{ dryad.install_dir }}/config/registries/workflow-types.xml
 {{ dryad.install_dir }}/bin/dsrun org.dspace.administer.MetadataImporter -f {{ dryad.install_dir }}/config/registries/internal-types.xml
-{{ dryad.install_dir }}/bin/dsrun org.dspace.administer.MetadataImporter -f {{ dryad.install_dir }}/config/registries//prism-types.xml
+{{ dryad.install_dir }}/bin/dsrun org.dspace.administer.MetadataImporter -f {{ dryad.install_dir }}/config/registries/prism-types.xml
+{{ dryad.install_dir }}/bin/dsrun org.dspace.administer.MetadataImporter -f {{ dryad.install_dir }}/config/registries/journal-types.xml
 
 echo "Updating sequences"
 psql < {{ dryad.install_dir }}/etc/postgres/update-sequences.sql


### PR DESCRIPTION
Somehow the journal-types registry never got added to the install script.