### PR TITLE
Add script to update the Mirage theme

### DIFF
--- a/ansible-dryad/roles/dryad_app/tasks/dryad_code.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_code.yml
@@ -74,6 +74,10 @@
   template: src=build_indexes.sh.j2 dest="{{ dryad.user_home }}/bin/build_indexes.sh" mode=0755
   sudo: no
 
+- name: Install script to update the theme without a full redeploy
+  template: src=update_theme.sh.j2 dest="{{ dryad.user_home }}/bin/update_theme.sh" mode=0755
+  sudo: no
+
 - name: Install database script
   template: src=install_dryad_database.sh.j2 dest="{{ dryad.user_home }}/bin/install_dryad_database.sh" mode=0755
 

--- a/ansible-dryad/roles/dryad_app/templates/update_theme.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/update_theme.sh.j2
@@ -1,0 +1,12 @@
+# Update the Mirage theme in the deployed directory, 
+# using the theme from the currently checked out branch
+
+cp /home/vagrant/dryad-repo/dspace/config/pages/* /opt/dryad/config/pages/
+rm -rf /opt/dryad/webapps/xmlui/themes/Mirage/pages
+cp -r /home/vagrant/dryad-repo/dspace/modules/xmlui/src/main/webapp/themes/Mirage/pages /opt/dryad/webapps/xmlui/themes/Mirage
+rm -rf /opt/dryad/webapps/xmlui/themes/Mirage/images
+cp -r /home/vagrant/dryad-repo/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/Mirage/images /opt/dryad/webapps/xmlui/themes/Mirage
+cp -r /home/vagrant/dryad-repo/dspace/modules/xmlui/src/main/webapp/themes/Mirage/images /opt/dryad/webapps/xmlui/themes/Mirage
+rm -rf /opt/dryad/webapps/xmlui/themes/Mirage/docs
+cp -r /home/vagrant/dryad-repo/dspace/modules/xmlui/src/main/webapp/themes/Mirage/docs /opt/dryad/webapps/xmlui/themes/Mirage
+cp /home/vagrant/dryad-repo/dspace/modules/xmlui/src/main/webapp/themes/Mirage/Mirage.xsl /opt/dryad/webapps/xmlui/themes/Mirage/Mirage.xsl


### PR DESCRIPTION
Updates the contents of the theme, including static pages. This is useful
when creating updates to the static content, because the update process is
much faster than a full compile/deploy cycle.