### PR TITLE
Add a notes to the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ It is likely that the initial provisioning will fail, because the VM does not ha
 - create an ssh keypair (`ssh-keygen`)
 - view the public key (`cat .ssh/id_rsa.pub`)
 - copy and paste the public key into to your settings on GitHub.
+- log out of the VM (`exit`)
+- re-start the provisioning (`vagrant provision`)
 
 Sometimes provisioning fails with `fatal: [x.x.x.x] => SSH encountered an unknown error during the connection.`.  In this case simply retry with `vagrant provision`.
 

--- a/packer-templates/README.md
+++ b/packer-templates/README.md
@@ -16,7 +16,7 @@ vagrant box remove precise64-10g
 vagrant box remove dryad-ubuntu-12-04
 ```
 
-Then run the `vagrant-box-dryad.sh` script from inside its directory.
+Then run the `vagrant-box-dryad.sh` script from inside its directory. This script takes a while; be patient for it, and don't type anything when the terminal window opens, just wait for the build process to happen.
 
 The new box can be used to replace the default Vagrant box in the Vagrantfile: 
 


### PR DESCRIPTION
Ensure users wait for the packer process, rather than typing to interrupt it.

Add clarifications to process for GitHub SSH.