### PR TITLE
Allow redeploy to work when tomcat is not running

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/redeploy_dryad.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/redeploy_dryad.sh.j2
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-set -e
 {{ dryad.user_home }}/bin/tomcat_stop.sh
+
+# Stop if there is an error (so we can see the error message)
+# But there isn't a need to stop if the tomcat_stop fails, because that
+# means that tomcat wasn't running in the first place.
+set -e
+
 {{ dryad.user_home }}/bin/build_dryad.sh
 {{ dryad.user_home }}/bin/deploy_dryad.sh
 {{ dryad.user_home }}/bin/tomcat_start.sh


### PR DESCRIPTION
If tomcat was not running, the tomcat_stop.sh would return an error,
which would halt redeploy_dryad.sh. This commit changes redeploy_dryad.sh
to work correctly if tomcat is not running.