### PR TITLE
Allow separate settings for production vs test machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ansible-dryad/group_vars/all
 sync/
 packer-templates/ubuntu-12.04/packer_cache
 packer-templates/ubuntu-12.04/ubuntu-12-04-x64-virtualbox.box
+ansible-dryad/setup.retry

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -112,7 +112,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	   'Name' => ENV["DRYAD_AWS_VM_NAME"]
     }	   
     # From http://cloud-images.ubuntu.com/locator/ec2/
-    # us-east-1	precise	12.04 LTS	amd64	ebs	20140606	ami-a49665cc	aki-919dcaf8
+    # us-east-1	xenial	16.04 LTS	amd64	hvm-ssd	20180109	ami-41e0b93b
     aws.ami = "ami-41e0b93b"
     aws.instance_type = "t2.small"
     aws.security_groups = ['AWS-OpsWorks-Default-Server', 'default']

--- a/ansible-dryad/group_vars/all.template
+++ b/ansible-dryad/group_vars/all.template
@@ -34,7 +34,6 @@ dryad:
   curator_internal_email: root@localhost
   automated_email: root@localhost
   curator_apu_email: root@localhost
-  mail_disabled: true ## set to false if this is to be a production server
   apu_token: ''
   host: 192.168.111.223
   hostname: localhost ## This must match the machine's public DNS name, or some links will fail. ##

--- a/ansible-dryad/group_vars/all.template
+++ b/ansible-dryad/group_vars/all.template
@@ -20,6 +20,7 @@ postgresql:
 
 dryad:
   is_production: false
+  instance_name: "{{ lookup('env', 'DRYAD_AWS_VM_NAME') }}"
   user: ubuntu
   user_home: /home/ubuntu
   java:

--- a/ansible-dryad/group_vars/all.template
+++ b/ansible-dryad/group_vars/all.template
@@ -19,6 +19,7 @@ postgresql:
     effective_cache_size: 128MB
 
 dryad:
+  is_production: false
   user: ubuntu
   user_home: /home/ubuntu
   java:

--- a/ansible-dryad/roles/dryad_app/tasks/main.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- include: repository.yml
-- include: dryad_environment.yml
-- include: dryad_deps.yml
-- include: dryad_setupdb.yml
-- include: dryad_code.yml
-- include: dryad_apache.yml
+- include_tasks: repository.yml
+- include_tasks: dryad_environment.yml
+- include_tasks: dryad_deps.yml
+- include_tasks: dryad_setupdb.yml
+- include_tasks: dryad_code.yml
+- include_tasks: dryad_apache.yml

--- a/ansible-dryad/roles/dryad_app/templates/aws_opsworks.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/aws_opsworks.sh.j2
@@ -6,6 +6,7 @@ aws opsworks register --region {{ dryad.aws.regionName }} --infrastructure-class
 echo "Waiting for instance to register..."
 sleep 5
 INSTANCE_ID=$(sudo opsworks-agent-cli stack_state | sed -n 's/\"instance_id\"\://p' | sed -n 's/\s//pg' | sed -n 's/"//pg' | sed -n 's/,//pg')
+EC2_INSTANCE_ID=$(sudo opsworks-agent-cli stack_state | sed -n 's/\"ec2_instance_id\"\://p' | sed -n 's/\s//pg' | sed -n 's/"//pg' | sed -n 's/,//pg')
 
 while [ $INSTANCE_ID == "" ]; do
 	echo "still waiting for instance to register..."
@@ -22,3 +23,7 @@ if [ {{ dryad.is_production }} != True ]; then
 	echo "Assigning instance to Test Machines layer"
 	aws opsworks update-instance --instance-id $INSTANCE_ID --layer-ids ecff7e23-92f9-479a-805d-024673631a19
 fi
+
+EC2_INSTANCE_ID=$(sudo opsworks-agent-cli stack_state | sed -n 's/\"ec2_instance_id\"\://p' | sed -n 's/\s//pg' | sed -n 's/"//pg' | sed -n 's/,//pg')
+echo "Adding EC2 name to $EC2_INSTANCE_ID"
+aws ec2 create-tags --resources $EC2_INSTANCE_ID --tags Key=Name,Value={{ dryad.instance_name }}

--- a/ansible-dryad/roles/dryad_app/templates/aws_opsworks.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/aws_opsworks.sh.j2
@@ -3,8 +3,7 @@
 echo "Registering instance with AWS OpsWorks..."
 aws opsworks register --region {{ dryad.aws.regionName }} --infrastructure-class ec2 --stack-id c05bd570-7890-4579-8edb-826332df7e04 --local
 
-echo "Assigning instance to Dryad Servers layer"
-
+echo "Waiting for instance to register..."
 sleep 5
 INSTANCE_ID=$(sudo opsworks-agent-cli stack_state | sed -n 's/\"instance_id\"\://p' | sed -n 's/\s//pg' | sed -n 's/"//pg' | sed -n 's/,//pg')
 
@@ -14,4 +13,12 @@ while [ $INSTANCE_ID == "" ]; do
 	INSTANCE_ID=$(sudo opsworks-agent-cli stack_state | sed -n 's/\"instance_id\"\://p' | sed -n 's/\s//pg' | sed -n 's/"//pg' | sed -n 's/,//pg')
 done
 
-aws opsworks update-instance --instance-id $INSTANCE_ID --layer-ids 0e95b566-d572-4a2d-a83b-a7018e451c19
+if [ {{ dryad.is_production }} = True ]; then
+	echo "Assigning instance to Dryad Servers layer"
+	aws opsworks update-instance --instance-id $INSTANCE_ID --layer-ids 0e95b566-d572-4a2d-a83b-a7018e451c19
+fi
+
+if [ {{ dryad.is_production }} != True ]; then
+	echo "Assigning instance to Test Machines layer"
+	aws opsworks update-instance --instance-id $INSTANCE_ID --layer-ids ecff7e23-92f9-479a-805d-024673631a19
+fi

--- a/ansible-dryad/roles/dryad_app/templates/aws_opsworks.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/aws_opsworks.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Registering instance with AWS OpsWorks..."
-aws opsworks register --region {{ dryad.aws.regionName }} --infrastructure-class ec2 --stack-id c05bd570-7890-4579-8edb-826332df7e04 --local
+aws opsworks register --region {{ dryad.aws.regionName }} --infrastructure-class ec2 --stack-id c05bd570-7890-4579-8edb-826332df7e04 --local --override-hostname {{ dryad.instance_name }}
 
 echo "Waiting for instance to register..."
 sleep 5

--- a/ansible-dryad/roles/dryad_app/templates/pgpass.j2
+++ b/ansible-dryad/roles/dryad_app/templates/pgpass.j2
@@ -1,2 +1,2 @@
-{{ dryad.db.host }}:{{ dryad.db.port }}:{{ dryad.db.name }}:{{ dryad.db.user }}:{{ dryad.db.password }}
+{{ dryad.db.host }}:{{ dryad.db.port }}:*:{{ dryad.db.user }}:{{ dryad.db.password }}
 {{ dryad.testdb.host }}:{{ dryad.testdb.port }}:{{ dryad.testdb.name }}:{{ dryad.testdb.user }}:{{ dryad.testdb.password }}

--- a/ansible-dryad/roles/dryad_app/templates/redeploy_dryad.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/redeploy_dryad.sh.j2
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# clean up old copies:
+rm /opt/dryad/config/*.old
+rm /opt/dryad/config/modules/*.old
+
 {{ dryad.user_home }}/bin/tomcat_stop.sh
 
 # Stop if there is an error (so we can see the error message)

--- a/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
+++ b/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
@@ -44,7 +44,7 @@
 				<default.mail.server>localhost</default.mail.server>
 				<default.mail.server.username></default.mail.server.username>
 				<default.mail.server.password></default.mail.server.password>
-				<default.mail.server.disabled>{{ dryad.mail_disabled }}</default.mail.server.disabled>
+				<default.mail.server.disabled>{% if dryad.is_production %}false{% else %}true{% endif %}</default.mail.server.disabled>
 				<default.mail.extraproperties>mail.smtp.socketFactory.port=1025</default.mail.extraproperties>
 				<default.mail.admin>{{ dryad.admin_email }}</default.mail.admin>
 				<default.mail.help>{{ dryad.admin_email }}</default.mail.help>

--- a/ansible-dryad/roles/postgresql/tasks/main.yml
+++ b/ansible-dryad/roles/postgresql/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: repository.yml
-- include: postgresql.yml
+- include_tasks: repository.yml
+- include_tasks: postgresql.yml


### PR DESCRIPTION
Allow several settings to be set based on whether or not the machine is a production machine.
Also adds the instance name to Opsworks when registering.

(also updates some deprecated settings and ignores setup.retry files)