### PR TITLE
Apache tweaks2

### DIFF
--- a/ansible-dryad/group_vars/all.template
+++ b/ansible-dryad/group_vars/all.template
@@ -20,6 +20,7 @@ postgresql:
 
 dryad:
   is_production: false
+  is_readonly: false
   instance_name: "{{ lookup('env', 'DRYAD_AWS_VM_NAME') }}"
   user: ubuntu
   user_home: /home/ubuntu

--- a/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
@@ -1,4 +1,8 @@
 ---
+- name: Ensure dpkg is set up to remove any previous apache
+  shell: dpkg --configure -a
+  become: yes
+
 - name: Purge the apache webserver
   apt: pkg={{ item }} state=absent purge=yes
   with_items:
@@ -33,10 +37,10 @@
   file: path={{ dryad.user_home }}/apache state=directory owner={{ dryad.user }} mode=0755
 
 - name: Create symlink for access to apache config
-  file: src=/etc/apache2/ dest={{ dryad.user_home }}/apache/conf state=link owner={{ dryad.user }}
+  file: src=/etc/apache2 dest={{ dryad.user_home }}/apache/conf state=link owner={{ dryad.user }}
 
 - name: Create symlink for access to apache logs
-  file: src=/var/log/apache2/ dest={{ dryad.user_home }}/apache/log state=link owner={{ dryad.user }}
+  file: src=/var/log/apache2 dest={{ dryad.user_home }}/apache/log state=link owner={{ dryad.user }}
 
 - name: Restart apache to pick up the new config settings
   service: name=apache2 state=restarted

--- a/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
@@ -29,6 +29,15 @@
   template: src=apache_default_virtualhost.j2 dest="/etc/apache2/sites-enabled/000-default.conf"
   become: yes
 
+- name: Create apache convenience directory
+  file: path={{ dryad.user_home }}/apache state=directory owner={{ dryad.user }} mode=0755
+
+- name: Create symlink for access to apache config
+  file: src=/etc/apache2/ dest={{ dryad.user_home }}/apache/conf state=link owner={{ dryad.user }}
+
+- name: Create symlink for access to apache logs
+  file: src=/var/log/apache2/ dest={{ dryad.user_home }}/apache/log state=link owner={{ dryad.user }}
+
 - name: Restart apache to pick up the new config settings
   service: name=apache2 state=restarted
   become: yes

--- a/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
@@ -23,6 +23,7 @@
     - proxy
     - proxy_ajp
     - rewrite
+    - substitute
   become: yes
 
 - name: Copy apache proxy config

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -11,6 +11,18 @@
 	AddDefaultCharset UTF-8
 	ProxyPreserveHost On
 
+{% if dryad.is_readonly %}
+        # Disable submission, since this is a readonly server                                                                                        
+        <LocationMatch "/">
+            AddOutputFilterByType SUBSTITUTE text/html
+            Substitute "s|<a class=\"submitnowbutton.*</a>|Submissions have been temporarily disabled.|i"
+            Substitute "s|<span id=\"login-item\">Log in</span>||i"
+            Substitute "s|<span id=\"sign-up-item\">Sign up</span>||i"
+            Substitute "s|How and why\?||i"
+        </LocationMatch>
+        Redirect /login /maintenance
+        Redirect /password-login /maintenance
+{% endif %}
 
         RewriteEngine On
 

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -12,8 +12,8 @@
 	ProxyPreserveHost On
 
 {% if dryad.is_readonly %}
-        # Disable submission, since this is a readonly server                                                                                        
-        <LocationMatch "/">
+        # Disable submission, since this is a readonly server
+	<LocationMatch "/">
             AddOutputFilterByType SUBSTITUTE text/html
             Substitute "s|<a class=\"submitnowbutton.*</a>|Submissions have been temporarily disabled.|i"
             Substitute "s|<span id=\"login-item\">Log in</span>||i"

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -13,15 +13,17 @@
 
 {% if dryad.is_readonly %}
         # Disable submission, since this is a readonly server
-	<LocationMatch "/">
-            AddOutputFilterByType SUBSTITUTE text/html
-            Substitute "s|<a class=\"submitnowbutton.*</a>|Submissions have been temporarily disabled.|i"
-            Substitute "s|<span id=\"login-item\">Log in</span>||i"
-            Substitute "s|<span id=\"sign-up-item\">Sign up</span>||i"
-            Substitute "s|How and why\?||i"
-        </LocationMatch>
-        Redirect /login /maintenance
-        Redirect /password-login /maintenance
+        <Location "/">
+           SetOutputFilter SUBSTITUTE;DEFLATE
+           AddOutputFilterByType SUBSTITUTE text/html
+           Substitute "s|<a class=\"submitnowbutton.*</a>|Submissions have been temporarily disabled.|i"
+           Substitute "s|span\ id=\"login-item\">Log in</span>|span></span>|i"
+           Substitute "s|span\ id=\"sign-up-item\">Sign up</span>|span></span>|i"
+           Substitute "s|Sign up||i"
+           Substitute "s|How and why\?||i"
+        </Location>
+        RewriteRule ^/login /error
+        RewriteRule ^/password-login /error
 {% endif %}
 
         RewriteEngine On


### PR DESCRIPTION
Improve apache installation
- add an "apache" directory to the user's home for convenient access to apache configs/logs
- fix "dpkg" error that was stopping apache install when reprovisioning a server
- add the option for a server to be readonly (e.g., secundus), This option is disabled by default. To test,  set is_readonly to true and look at the resultant server's login/submission buttons.