### PR TITLE
Remove outdated parameter

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
+++ b/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
@@ -62,7 +62,6 @@
 				<default.submit.journal.email></default.submit.journal.email>
 				<default.submit.journal.label>journal-submit</default.submit.journal.label>
 				<default.submit.journal.error.label>journal-submit-error</default.submit.journal.error.label>
-				<default.submit.journal.email.timer>60</default.submit.journal.email.timer>
 				<default.submit.journal.clientsecret>{{ dryad.journal.clientsecret }}</default.submit.journal.clientsecret>
 
 				<!-- DataONE Member Node -->


### PR DESCRIPTION
The email timer was removed, so we no longer need a config setting for it.