### PR TITLE
Tomcat jmx env

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/bash_profile.j2
+++ b/ansible-dryad/roles/dryad_app/templates/bash_profile.j2
@@ -31,10 +31,6 @@ if [ ! -f $HOME/.gitconfig ]; then
   echo
 fi
 
-# Tomcat JMX settings
-export JMXPORT={{dryad.jmx.port}}
-export JMXHOST={{dryad.host}}
-
 # Maven PermGen settings
 export MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=128m"
 

--- a/ansible-dryad/roles/dryad_app/templates/tomcat_start.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/tomcat_start.sh.j2
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# Tomcat JMX settings
+export JMXPORT={{dryad.jmx.port}}
+export JMXHOST={{dryad.host}}
+
 {{ dryad.tomcat_home }}/bin/startup.sh


### PR DESCRIPTION
Move the JMX environment variables into the tomcat_start script so they take effect when the script is called from cron.

This is currently in place on secundus.