### PR TITLE
Add redirect for the Dryad Logo

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -37,6 +37,7 @@
 	RewriteRule ^/docs$ /themes/Mirage/docs [R=301]
 	RewriteRule ^/submit$ /handle/10255/3/submit [R]
 	RewriteRule ^/repo(.*)$ http://www.datadryad.org$1 [P,R=301]
+        RewriteRule ^/dryadLogo.png$ /themes/Dryad/images/dryadLogo.png [R=301]
 	RewriteRule ^/about$ /pages/organization [R=301]
 	RewriteRule ^/members$ /pages/membershipOverview [R=301]
 	RewriteRule ^/jdap$ /pages/jdap [R=301]


### PR DESCRIPTION
To be used by systems such as the Dryad blog.