### PR TITLE
Default SOLR settings to localhost

### DIFF
--- a/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
+++ b/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
@@ -21,13 +21,13 @@
 				<default.harvester.eperson>{{ dryad.admin_email }}</default.harvester.eperson>
 
 				<!-- SOLR indexes -->
-				<default.solr.search.server>{{ dryad.url }}/solr/search/</default.solr.search.server>
-				<default.solr.stats.server>{{ dryad.url }}/solr/statistics</default.solr.stats.server>
-				<default.solr.dryad.server>{{ dryad.url }}/solr/dryad</default.solr.dryad.server>
-				<default.solr.authority.server>{{ dryad.url }}/solr/authority</default.solr.authority.server>
-				<default.solr.log.dataonemn.server>{{ dryad.url }}/solr/dataoneMNlog</default.solr.log.dataonemn.server>
-				<default.solr.responselogging.server>{{ dryad.url }}/solr/responselogging</default.solr.responselogging.server>
-				<default.solr.xoai.server>{{ dryad.url }}/solr/xoai</default.solr.xoai.server>
+				<default.solr.search.server>localhost/solr/search/</default.solr.search.server>
+				<default.solr.stats.server>localhost/solr/statistics</default.solr.stats.server>
+				<default.solr.dryad.server>localhost/solr/dryad</default.solr.dryad.server>
+				<default.solr.authority.server>localhost/solr/authority</default.solr.authority.server>
+				<default.solr.log.dataonemn.server>localhost/solr/dataoneMNlog</default.solr.log.dataonemn.server>
+				<default.solr.responselogging.server>localhost/solr/responselogging</default.solr.responselogging.server>
+				<default.solr.xoai.server>localhost/solr/xoai</default.solr.xoai.server>
 
 				<!-- DOI -->
 				<default.doi.username>{{ dryad.doi.username }}</default.doi.username>

--- a/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
+++ b/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
@@ -35,9 +35,9 @@
 				<default.doi.prefix>10.5061</default.doi.prefix>
 				<default.doi.testprefix>10.5072</default.doi.testprefix>
 				<default.doi.localpart.testsuffix>FK2dryad.</default.doi.localpart.testsuffix>
-				<default.doi.testmode>true</default.doi.testmode>
+				<default.doi.testmode>{% if dryad.is_production %}false{% else %}true{% endif %}</default.doi.testmode>
 				<default.dryad.localize>true</default.dryad.localize>
-				<default.doi.datacite.connected>false</default.doi.datacite.connected>
+				<default.doi.datacite.connected>{% if dryad.is_production %}true{% else %}false{% endif %}</default.doi.datacite.connected>
 				<default.doi.service>{{ dryad.url }}/doi</default.doi.service>
 
 				<!-- Email -->
@@ -46,10 +46,10 @@
 				<default.mail.server.password></default.mail.server.password>
 				<default.mail.server.disabled>{% if dryad.is_production %}false{% else %}true{% endif %}</default.mail.server.disabled>
 				<default.mail.extraproperties>mail.smtp.socketFactory.port=1025</default.mail.extraproperties>
-				<default.mail.admin>{{ dryad.admin_email }}</default.mail.admin>
-				<default.mail.help>{{ dryad.admin_email }}</default.mail.help>
-				<default.subscribe_mailinglist.recipient>{{ dryad.admin_email }}</default.subscribe_mailinglist.recipient>
-				<default.membership.recipient>{{ dryad.admin_email }}</default.membership.recipient>
+				<default.mail.admin>{% if dryad.is_production %}help@datadryad.org{% else %}{{ dryad.admin_email }}{% endif %}</default.mail.admin>
+				<default.mail.help>{% if dryad.is_production %}help@datadryad.org{% else %}{{ dryad.admin_email }}{% endif %}</default.mail.help>
+				<default.subscribe_mailinglist.recipient>{% if dryad.is_production %}help@datadryad.org{% else %}{{ dryad.admin_email }}{% endif %}</default.subscribe_mailinglist.recipient>
+				<default.membership.recipient>{% if dryad.is_production %}help@datadryad.org{% else %}{{ dryad.admin_email }}{% endif %}</default.membership.recipient>
 				<default.curator_errors.recipient>{{ dryad.curator_internal_email }}</default.curator_errors.recipient>
 				<default.automated.email.recipient>{{ dryad.automated_email }}</default.automated.email.recipient>
 
@@ -73,7 +73,7 @@
 				<paypal.vendor>{{ dryad.paypal.vendor }}</paypal.vendor>
 				<paypal.user>{{ dryad.paypal.user }}</paypal.user>
 				<paypal.pwd>{{ dryad.paypal.password }}</paypal.pwd>
-				<paypal.payflow.link>https://pilot-payflowpro.paypal.com/</paypal.payflow.link>
+				<paypal.payflow.link>{% if dryad.is_production %}https://payflowpro.paypal.com/{% else %}https://pilot-payflowpro.paypal.com/{% endif %}</paypal.payflow.link>
 				<paypal.link>https://payflowlink.paypal.com</paypal.link>
 				<paypal.partner>PayPal</paypal.partner>
 				<paypal.verbosity>HIGH</paypal.verbosity>


### PR DESCRIPTION
This is most important for production, because the setting for "datadryad.org" could be
a different machine, which would lead to confusing search results.