### PR TITLE
Production upgrades

### DIFF
--- a/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
@@ -39,6 +39,10 @@
   template: src=apache_ssl_virtualhost.j2 dest="/etc/apache2/sites-enabled/ssl.conf"
   become: yes
 
+- name: Ensure certs directory is present and writable
+  when: dryad.is_production
+  file: path=/etc/apache2/certs state=directory owner={{ dryad.user }} mode=0755
+
 - name: Get SSL cert main
   when: dryad.is_production
   aws_s3:

--- a/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
@@ -34,6 +34,51 @@
   template: src=apache_default_virtualhost.j2 dest="/etc/apache2/sites-enabled/000-default.conf"
   become: yes
 
+- name: Copy apache SSL config with redirects
+  when: dryad.is_production
+  template: src=apache_ssl_virtualhost.j2 dest="/etc/apache2/sites-enabled/ssl.conf"
+  become: yes
+
+- name: Get SSL cert main
+  when: dryad.is_production
+  aws_s3:
+    bucket: dryad-backup
+    object: apache/2017.datadryad.org.crt
+    dest: "/etc/apache2/certs/2017.datadryad.org.crt"
+    mode: get
+  become: no
+  ignore_errors: yes
+
+- name: Get SSL cert CA
+  when: dryad.is_production
+  aws_s3:
+    bucket: dryad-backup
+    object: apache/2017.datadryad.org.ca-bundle
+    dest: "/etc/apache2/certs/2017.datadryad.org.ca-bundle"
+    mode: get
+  become: no
+  ignore_errors: yes
+
+- name: Get SSL cert key
+  when: dryad.is_production
+  aws_s3:
+    bucket: dryad-backup
+    object: apache/2017.datadryad.org.key
+    dest: "/etc/apache2/certs/2017.datadryad.org.key"
+    mode: get
+  become: no
+  ignore_errors: yes
+
+- name: Get SSL cert DataONE
+  when: dryad.is_production
+  aws_s3:
+    bucket: dryad-backup
+    object: apache/DataONECAChain.crt
+    dest: "/etc/apache2/certs/DataONECAChain.crt"
+    mode: get
+  become: no
+  ignore_errors: yes
+
 - name: Create apache convenience directory
   file: path={{ dryad.user_home }}/apache state=directory owner={{ dryad.user }} mode=0755
 

--- a/ansible-dryad/roles/dryad_app/tasks/dryad_environment.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_environment.yml
@@ -4,7 +4,7 @@
 #  async: 60
 #  poll: 60
   with_items:
-    - emacs24
+    - emacs
     - ack-grep
     - python-pip
     - mailutils

--- a/ansible-dryad/roles/dryad_app/tasks/dryad_environment.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_environment.yml
@@ -6,22 +6,11 @@
   with_items:
     - emacs
     - ack-grep
+    - libffi-dev 
+    - libssl-dev
     - python-pip
     - mailutils
-
-- name: Force pip to upgrade itself
-  shell: pip install --upgrade pip -i https://pypi.org/simple/
-  become: yes
-
-#  shell: ln -s /usr/local/bin/pip /usr/bin/
-- name: Link new pip into the path
-  file: src="/usr/local/bin/pip" dest="/usr/bin/pip" state=link
-
-- name: Clone dryad-utils repo
-  git: repo=https://github.com/{{ dryad.github_user }}/dryad-utils.git
-       dest="{{ dryad.user_home }}/dryad-utils"
-       accept_hostkey=yes
-  become: no
+    - python-dev 
 
 - name: Copy pip requirements into place
   template: src=requirements.txt.j2 dest="{{ dryad.user_home }}/requirements.txt" mode=0600 owner={{ dryad.user }}
@@ -31,6 +20,12 @@
   pip: 
     requirements: "{{ dryad.user_home }}/requirements.txt"
   become: yes
+
+- name: Clone dryad-utils repo
+  git: repo=https://github.com/{{ dryad.github_user }}/dryad-utils.git
+       dest="{{ dryad.user_home }}/dryad-utils"
+       accept_hostkey=yes
+  become: no
   
 - name: Create hidden dir for AWS
   file: path={{ dryad.user_home }}/.aws state=directory owner={{ dryad.user }} mode=0755

--- a/ansible-dryad/roles/dryad_app/tasks/dryad_environment.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_environment.yml
@@ -9,16 +9,28 @@
     - python-pip
     - mailutils
 
+- name: Force pip to upgrade itself
+  shell: pip install --upgrade pip -i https://pypi.org/simple/
+  become: yes
+
+#  shell: ln -s /usr/local/bin/pip /usr/bin/
+- name: Link new pip into the path
+  file: src="/usr/local/bin/pip" dest="/usr/bin/pip" state=link
+
 - name: Clone dryad-utils repo
   git: repo=https://github.com/{{ dryad.github_user }}/dryad-utils.git
        dest="{{ dryad.user_home }}/dryad-utils"
        accept_hostkey=yes
   become: no
 
+- name: Copy pip requirements into place
+  template: src=requirements.txt.j2 dest="{{ dryad.user_home }}/requirements.txt" mode=0600 owner={{ dryad.user }}
+  remote_user: "{{ dryad.user }}"
+
 - name: Install python packages
   pip: 
-    requirements: "{{ dryad.user_home }}/dryad-utils/requirements.txt"
-  become: no
+    requirements: "{{ dryad.user_home }}/requirements.txt"
+  become: yes
   
 - name: Create hidden dir for AWS
   file: path={{ dryad.user_home }}/.aws state=directory owner={{ dryad.user }} mode=0755

--- a/ansible-dryad/roles/dryad_app/tasks/dryad_setupdb.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_setupdb.yml
@@ -7,9 +7,10 @@
   become: yes
 
 - name: Create Postgres user for dryad
-  postgresql_user: name={{ dryad.db.user }} role_attr_flags=CREATEDB password={{ dryad.db.password }}
   become: yes
   become_user: postgres
+  postgresql_user: name={{ dryad.db.user }} role_attr_flags=CREATEDB password={{ dryad.db.password }}
+  
 
 - name: Create Postgres database for dryad
   postgresql_db: owner={{ dryad.db.user }} name={{ dryad.db.name }} login_user={{ dryad.db.user }} login_password={{ dryad.db.password }} login_host={{ dryad.db.host }} port={{ dryad.db.port }} encoding={{ postgresql.encoding }} lc_ctype='{{ postgresql.locale }}.{{ postgresql.encoding }}' lc_collate='{{ postgresql.locale }}.{{ postgresql.encoding }}'

--- a/ansible-dryad/roles/dryad_app/tasks/main.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - include_tasks: repository.yml
-- include_tasks: dryad_environment.yml
 - include_tasks: dryad_deps.yml
+- include_tasks: dryad_environment.yml
 - include_tasks: dryad_setupdb.yml
 - include_tasks: dryad_code.yml
 - include_tasks: dryad_apache.yml

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -28,6 +28,22 @@
 
         RewriteEngine On
 
+{% if dryad.is_production %}
+	# Force all major requests to https
+	RewriteRule ^/(login.*)$ https://datadryad.org/$1 [R=permanent]
+	RewriteRule ^/(resource.*)$ https://datadryad.org/$1 [R=permanent]
+	RewriteRule ^/(theme.*)$ https://datadryad.org/$1 [R=permanent]
+	RewriteRule ^/(discover.*)$ https://datadryad.org/$1 [R=permanent]
+	RewriteRule ^/(admin.*)$ https://datadryad.org/$1 [R=permanent]
+	RewriteRule ^/(submit.*)$ https://datadryad.org/$1 [R=permanent]
+	RewriteRule ^/(internal.*)$ https://datadryad.org/$1 [R=permanent]
+
+	# Send API requests to API server
+	RewriteRule ^/(oai.*)$ http://api.datadryad.org/$1 [R=permanent]
+	RewriteRule ^/(widget.*)$ http://api.datadryad.org/$1 [R=permanent]
+	RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
+{% endif %}
+
 	# Block DSpace security hole
 	# This redirects all vulnerable URLs to /error
 	# (which doesn't exist and throws a 404 response)
@@ -48,4 +64,23 @@
 	RewriteRule ^/dans-news$ http://wiki.datadryad.org/images/2/29/Dryad-DANS_Announcement.pdf
 	ProxyPass /dryadlab http://datadryad.org/pages/dryadlab
 	ProxyPassReverse /dryadlab http://datadryad.org/pages/dryadlab               
+
+	# Rewrite "&amp;" to "&" in query strings to fix the incorrectly encoded ampersand
+    	# for Journal of Fish and Wildlife
+    	RewriteCond %{QUERY_STRING} ^([^\?]*)\&amp;(.*)$
+    	RewriteRule ^(.*)$ $1\?%1&%2 [R]
+
+
+	# Rewrites for datadryad.org metadata profile -- linked to from XML docs; don't delete!!
+        RewriteRule ^/profile/v3/dryad.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dryad.xsd [R,L]
+	RewriteRule ^/profile/v3/dc.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dc.xsd [R,L]
+	RewriteRule ^/profile/v3/dcterms.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dcterms.xsd [R,L]
+	RewriteRule ^/profile/v3/dcmitype.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dcmitype.xsd [R,L]
+	RewriteRule ^/profile/v3/bibo.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/bib.xsd [R,L]
+
+	# Prevent external systems from writing to the SOLR index
+	ProxyPass /solr/search/update !
+	ProxyPassReverse /solr/search/update !
+	ProxyPass /solr/statistics/update !
+	ProxyPassReverse /solr/statistics/update !
 </VirtualHost>

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -123,4 +123,5 @@
   ProxyPassReverse /solr/search/update !
   ProxyPass /solr/statistics/update !
   ProxyPassReverse /solr/statistics/update !
+
 </VirtualHost>

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -71,13 +71,6 @@
     	RewriteRule ^(.*)$ $1\?%1&%2 [R]
 
 
-	# Rewrites for datadryad.org metadata profile -- linked to from XML docs; don't delete!!
-        RewriteRule ^/profile/v3/dryad.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dryad.xsd [R,L]
-	RewriteRule ^/profile/v3/dc.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dc.xsd [R,L]
-	RewriteRule ^/profile/v3/dcterms.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dcterms.xsd [R,L]
-	RewriteRule ^/profile/v3/dcmitype.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dcmitype.xsd [R,L]
-	RewriteRule ^/profile/v3/bibo.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/bib.xsd [R,L]
-
 	# Prevent external systems from writing to the SOLR index
 	ProxyPass /solr/search/update !
 	ProxyPassReverse /solr/search/update !

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -1,79 +1,80 @@
 <VirtualHost *:80>
 
-	ServerAdmin  help@datadryad.org  
-	DocumentRoot /var/www/html
+  ServerAdmin  help@datadryad.org  
+  DocumentRoot /var/www/html
+  
+  ErrorLog ${APACHE_LOG_DIR}/datadryad.org-error_log
+  CustomLog ${APACHE_LOG_DIR}/datadryad.org-access_log combined
+  
+  AllowEncodedSlashes On
+  AcceptPathInfo On
+  AddDefaultCharset UTF-8
+  ProxyPreserveHost On
 
-	ErrorLog ${APACHE_LOG_DIR}/datadryad.org-error_log
-	CustomLog ${APACHE_LOG_DIR}/datadryad.org-access_log combined
-
-	AllowEncodedSlashes On
-        AcceptPathInfo On
-	AddDefaultCharset UTF-8
-	ProxyPreserveHost On
+  RewriteEngine On
 
 {% if dryad.is_readonly %}
-        # Disable submission, since this is a readonly server
-        <Location "/">
-           SetOutputFilter SUBSTITUTE;DEFLATE
-           AddOutputFilterByType SUBSTITUTE text/html
-           Substitute "s|<a class=\"submitnowbutton.*</a>|Submissions have been temporarily disabled.|i"
-           Substitute "s|span\ id=\"login-item\">Log in</span>|span></span>|i"
-           Substitute "s|span\ id=\"sign-up-item\">Sign up</span>|span></span>|i"
-           Substitute "s|Sign up||i"
-           Substitute "s|How and why\?||i"
-        </Location>
-        RewriteRule ^/login /error
-        RewriteRule ^/password-login /error
-{% endif %}
+  # Disable submission, since this is a readonly server
+  <Location "/">
+    SetOutputFilter SUBSTITUTE;DEFLATE
+    AddOutputFilterByType SUBSTITUTE text/html
+    Substitute "s|<a class=\"submitnowbutton.*</a>|Submissions have been temporarily disabled.|i"
+    Substitute "s|span\ id=\"login-item\">Log in</span>|span></span>|i"
+    Substitute "s|span\ id=\"sign-up-item\">Sign up</span>|span></span>|i"
+    Substitute "s|Sign up||i"
+    Substitute "s|How and why\?||i"
+  </Location>
 
-        RewriteEngine On
+  RewriteRule ^/login /error
+  RewriteRule ^/password-login /error
+{% endif %}
 
 {% if dryad.is_production %}
-	# Force all major requests to https
-	RewriteRule ^/(login.*)$ https://datadryad.org/$1 [R=permanent]
-	RewriteRule ^/(resource.*)$ https://datadryad.org/$1 [R=permanent]
-	RewriteRule ^/(theme.*)$ https://datadryad.org/$1 [R=permanent]
-	RewriteRule ^/(discover.*)$ https://datadryad.org/$1 [R=permanent]
-	RewriteRule ^/(admin.*)$ https://datadryad.org/$1 [R=permanent]
-	RewriteRule ^/(submit.*)$ https://datadryad.org/$1 [R=permanent]
-	RewriteRule ^/(internal.*)$ https://datadryad.org/$1 [R=permanent]
+  # Force all major requests to https
+  RewriteRule ^/(login.*)$ https://datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(resource.*)$ https://datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(theme.*)$ https://datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(discover.*)$ https://datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(admin.*)$ https://datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(submit.*)$ https://datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(internal.*)$ https://datadryad.org/$1 [R=permanent]
 
-	# Send API requests to API server
-	RewriteRule ^/(oai.*)$ http://api.datadryad.org/$1 [R=permanent]
-	RewriteRule ^/(widget.*)$ http://api.datadryad.org/$1 [R=permanent]
-	RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
+  # Send API requests to API server
+  RewriteRule ^/(oai.*)$ http://api.datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(widget.*)$ http://api.datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
 {% endif %}
 
-	# Block DSpace security hole
-	# This redirects all vulnerable URLs to /error
-	# (which doesn't exist and throws a 404 response)
-	RewriteRule ^/+themes/.*:.*$ /error [R=permanent,L]
+  # Block DSpace security hole
+  # This redirects all vulnerable URLs to /error
+  # (which doesn't exist and throws a 404 response)
+  RewriteRule ^/+themes/.*:.*$ /error [R=permanent,L]
 
- 	# General rewrites for convenient URLs
-	RewriteRule ^/docs$ /themes/Mirage/docs [R=301]
-	RewriteRule ^/submit$ /handle/10255/3/submit [R]
-	RewriteRule ^/repo(.*)$ http://www.datadryad.org$1 [P,R=301]
-	RewriteRule ^/about$ /pages/organization [R=301]
-	RewriteRule ^/members$ /pages/membershipOverview [R=301]
-	RewriteRule ^/jdap$ /pages/jdap [R=301]
-	RewriteRule ^/policies$ /pages/policies [R=301]
-	RewriteRule ^/searching$ /pages/searching [R=301]
-	RewriteRule ^/depositing$ /pages/faq#depositing [NE,R=301]
-	RewriteRule ^/using$ /pages/faq#using [NE,R=301]
-	RewriteRule ^/publicationBlackout$ /pages/publicationBlackout [R=301]
-	RewriteRule ^/dans-news$ http://wiki.datadryad.org/images/2/29/Dryad-DANS_Announcement.pdf
-	ProxyPass /dryadlab http://datadryad.org/pages/dryadlab
-	ProxyPassReverse /dryadlab http://datadryad.org/pages/dryadlab               
+  # General rewrites for convenient URLs
+  RewriteRule ^/docs$ /themes/Mirage/docs [R=301]
+  RewriteRule ^/submit$ /handle/10255/3/submit [R]
+  RewriteRule ^/repo(.*)$ http://www.datadryad.org$1 [P,R=301]
+  RewriteRule ^/about$ /pages/organization [R=301]
+  RewriteRule ^/members$ /pages/membershipOverview [R=301]
+  RewriteRule ^/jdap$ /pages/jdap [R=301]
+  RewriteRule ^/policies$ /pages/policies [R=301]
+  RewriteRule ^/searching$ /pages/searching [R=301]
+  RewriteRule ^/depositing$ /pages/faq#depositing [NE,R=301]
+  RewriteRule ^/using$ /pages/faq#using [NE,R=301]
+  RewriteRule ^/publicationBlackout$ /pages/publicationBlackout [R=301]
+  RewriteRule ^/dans-news$ http://wiki.datadryad.org/images/2/29/Dryad-DANS_Announcement.pdf
+  ProxyPass /dryadlab http://datadryad.org/pages/dryadlab
+  ProxyPassReverse /dryadlab http://datadryad.org/pages/dryadlab               
 
-	# Rewrite "&amp;" to "&" in query strings to fix the incorrectly encoded ampersand
-    	# for Journal of Fish and Wildlife
-    	RewriteCond %{QUERY_STRING} ^([^\?]*)\&amp;(.*)$
-    	RewriteRule ^(.*)$ $1\?%1&%2 [R]
+  # Rewrite "&amp;" to "&" in query strings to fix the incorrectly encoded ampersand
+  # for Journal of Fish and Wildlife
+  RewriteCond %{QUERY_STRING} ^([^\?]*)\&amp;(.*)$
+  RewriteRule ^(.*)$ $1\?%1&%2 [R]
 
 
-	# Prevent external systems from writing to the SOLR index
-	ProxyPass /solr/search/update !
-	ProxyPassReverse /solr/search/update !
-	ProxyPass /solr/statistics/update !
-	ProxyPassReverse /solr/statistics/update !
+  # Prevent external systems from writing to the SOLR index
+  ProxyPass /solr/search/update !
+  ProxyPassReverse /solr/search/update !
+  ProxyPass /solr/statistics/update !
+  ProxyPassReverse /solr/statistics/update !
 </VirtualHost>

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -13,6 +13,36 @@
 
   RewriteEngine On
 
+  # Block IP addresses that don't respect our servers
+  #   -- The last one on the list must *not* have the OR option
+  # This is HighWire -- RewriteCond %{REMOTE_ADDR} ^104\.232\.31\.177 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^123\.456\.789\.1 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^52\.51\.235\.75 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^192\.107\.175\.11 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^158\.69\.26\.33 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^122\.233\.114\.84 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^180\.126\.232\.200 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^202\.46(.*) [NC]
+  RewriteRule ^(.*)$ - [F,L]
+
+  # block spiders that don't read the robots.txt and spiral out of control
+  #   -- The last one on the list must *not* have the OR option 
+  RewriteCond %{HTTP_USER_AGENT} ^.*Baiduspider.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*Ezooms.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^HuaweiSymantecSpider [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^Localbot [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*MJ12bot.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^Sosospider [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*Vagabondo.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*YandexBot.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*JikeSpider.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*ichiro.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*AhrefsBot.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*Ephorusbot.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*YandexMedia.* [NC]
+  RewriteRule .* - [F,L]
+
+
 {% if dryad.is_readonly %}
   # Disable submission, since this is a readonly server
   <Location "/">

--- a/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_default_virtualhost.j2
@@ -42,6 +42,9 @@
   RewriteCond %{HTTP_USER_AGENT} ^.*YandexMedia.* [NC]
   RewriteRule .* - [F,L]
 
+  # remove dot and comma from the end of query strings
+  RewriteCond %{QUERY_STRING} ^(.*)[.,]$
+  RewriteRule (.*) http://datadryad.org$1?%1 [P]
 
 {% if dryad.is_readonly %}
   # Disable submission, since this is a readonly server
@@ -70,10 +73,16 @@
   RewriteRule ^/(internal.*)$ https://datadryad.org/$1 [R=permanent]
 
   # Send API requests to API server
-  RewriteRule ^/(oai.*)$ http://api.datadryad.org/$1 [R=permanent]
+  RewriteRule ^/oai$ http://api.datadryad.org/oai/request?verb=Identify [R,L]
+  RewriteRule ^/oai/$ http://api.datadryad.org/oai/request?verb=Identify [R,L]
+  RewriteRule ^/(oai/.+)$ http://api.datadryad.org/$1 [R=permanent]
   RewriteRule ^/(widget.*)$ http://api.datadryad.org/$1 [R=permanent]
   RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
 {% endif %}
+
+  # remove dot and comma from the end of query strings
+  RewriteCond %{QUERY_STRING} ^(.*)[.,]$
+  RewriteRule (.*) http://datadryad.org$1?%1 [P]
 
   # Block DSpace security hole
   # This redirects all vulnerable URLs to /error
@@ -95,6 +104,13 @@
   RewriteRule ^/dans-news$ http://wiki.datadryad.org/images/2/29/Dryad-DANS_Announcement.pdf
   ProxyPass /dryadlab http://datadryad.org/pages/dryadlab
   ProxyPassReverse /dryadlab http://datadryad.org/pages/dryadlab               
+
+
+  # Rewrites for datadryad.org metadata profile -- linked to from XML docs; don't delete!!
+  RewriteRule ^/profile/v3.1/dryad.xsd$ https://raw.github.com/datadryad/dryad-repo/dryad-master/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3.1/dryad.xsd
+  RewriteRule ^/profile/v3.1/dcterms.xsd$ https://raw.github.com/datadryad/dryad-repo/dryad-master/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3.1/dcterms.xsd
+  RewriteRule ^/profile/v3.1/bibo.xsd$ https://raw.github.com/datadryad/dryad-repo/dryad-master/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3.1/bibo.xsd
+  RewriteRule ^/profile/v3.1$ https://raw.github.com/datadryad/dryad-repo/dryad-master/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3.1/dryad.xsd
 
   # Rewrite "&amp;" to "&" in query strings to fix the incorrectly encoded ampersand
   # for Journal of Fish and Wildlife

--- a/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
@@ -23,6 +23,35 @@ Listen 443
   SSLProxyEngine On
   
   RewriteEngine On
+
+  # Block IP addresses that don't respect our servers
+  #   -- The last one on the list must *not* have the OR option
+  # This is HighWire -- RewriteCond %{REMOTE_ADDR} ^104\.232\.31\.177 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^123\.456\.789\.1 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^52\.51\.235\.75 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^192\.107\.175\.11 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^158\.69\.26\.33 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^122\.233\.114\.84 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^180\.126\.232\.200 [NC,OR]
+  RewriteCond %{REMOTE_ADDR} ^202\.46(.*) [NC]
+  RewriteRule ^(.*)$ - [F,L]
+
+  # block spiders that don't read the robots.txt and spiral out of control
+  #   -- The last one on the list must *not* have the OR option 
+  RewriteCond %{HTTP_USER_AGENT} ^.*Baiduspider.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*Ezooms.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^HuaweiSymantecSpider [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^Localbot [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*MJ12bot.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^Sosospider [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*Vagabondo.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*YandexBot.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*JikeSpider.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*ichiro.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*AhrefsBot.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*Ephorusbot.* [NC,OR]
+  RewriteCond %{HTTP_USER_AGENT} ^.*YandexMedia.* [NC]
+  RewriteRule .* - [F,L]
   
 {% if dryad.is_production %}
   # Send API requests to API server

--- a/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
@@ -53,13 +53,6 @@ Listen 443
     ProxyPass /dryadlab http://datadryad.org/pages/dryadlab
     ProxyPassReverse /dryadlab http://datadryad.org/pages/dryadlab               
 
-    # Rewrites for datadryad.org metadata profile -- linked to from XML docs; don't delete!!
-    RewriteRule ^/profile/v3/dryad.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dryad.xsd [R,L]
-    RewriteRule ^/profile/v3/dc.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dc.xsd [R,L]
-    RewriteRule ^/profile/v3/dcterms.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dcterms.xsd [R,L]
-    RewriteRule ^/profile/v3/dcmitype.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dcmitype.xsd [R,L]
-    RewriteRule ^/profile/v3/bibo.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/bib.xsd [R,L]
-
     # Prevent external systems from writing to the SOLR index
     ProxyPass /solr/search/update !
     ProxyPassReverse /solr/search/update !

--- a/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
@@ -66,6 +66,22 @@ Listen 443
   RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
 {% endif %}
 
+{% if dryad.is_readonly %}
+  # Disable submission, since this is a readonly server
+  <Location "/">
+    SetOutputFilter SUBSTITUTE;DEFLATE
+    AddOutputFilterByType SUBSTITUTE text/html
+    Substitute "s|<a class=\"submitnowbutton.*</a>|Submissions have been temporarily disabled.|i"
+    Substitute "s|span\ id=\"login-item\">Log in</span>|span></span>|i"
+    Substitute "s|span\ id=\"sign-up-item\">Sign up</span>|span></span>|i"
+    Substitute "s|Sign up||i"
+    Substitute "s|How and why\?||i"
+  </Location>
+
+  RewriteRule ^/login /error
+  RewriteRule ^/password-login /error
+{% endif %}
+
   # Block DSpace security hole
   # This redirects all vulnerable URLs to /error
   # (which doesn't exist and throws a 404 response)

--- a/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
@@ -1,4 +1,4 @@
-LoadModule ssl_module modules/mod_ssl.so
+LoadModule ssl_module /usr/lib/apache2/modules/mod_ssl.so
 
 Listen 443
 <VirtualHost *:443>

--- a/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
@@ -1,0 +1,74 @@
+LoadModule ssl_module modules/mod_ssl.so
+
+Listen 443
+<VirtualHost *:443>
+    ServerName datadryad.org
+    ServerAlias www.datadryad.org
+    ServerAlias prod.datadryad.org
+    ErrorLog ${APACHE_LOG_DIR}/datadryad.org-error_log
+    CustomLog ${APACHE_LOG_DIR}/datadryad.org-access_log combined
+
+    AllowEncodedSlashes On
+    AcceptPathInfo On
+    AddDefaultCharset UTF-8
+    ProxyPreserveHost On
+							     
+    SSLEngine on
+
+    SSLCertificateKeyFile "/etc/apache2/certs/2017.datadryad.org.key"
+    SSLCertificateFile "/etc/apache2/certs/2017.datadryad.org.crt"
+    SSLCertificateChainFile "/etc/apache2/certs/2017.datadryad.org.ca-bundle"
+    SSLCipherSuite "ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:+LOW:!SSLv2:+EXP:+eNULL"
+    SSLCACertificateFile "/etc/apache2/certs/DataONECAChain.crt"
+    SSLProxyEngine On
+
+    RewriteEngine On
+
+{% if dryad.is_production %}
+    # Send API requests to API server
+    RewriteRule ^/(oai.*)$ http://api.datadryad.org/$1 [R=permanent]
+    RewriteRule ^/(widget.*)$ http://api.datadryad.org/$1 [R=permanent]
+    RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
+{% endif %}
+
+    # Block DSpace security hole
+    # This redirects all vulnerable URLs to /error
+    # (which doesn't exist and throws a 404 response)
+    RewriteRule ^/+themes/.*:.*$ /error [R=permanent,L]
+
+    # General rewrites for convenient URLs
+    RewriteRule ^/docs$ /themes/Mirage/docs [R=301]
+    RewriteRule ^/submit$ /handle/10255/3/submit [R]
+    RewriteRule ^/repo(.*)$ http://www.datadryad.org$1 [P,R=301]
+    RewriteRule ^/dryadLogo.png$ /themes/Dryad/images/dryadLogo.png [R=301]
+    RewriteRule ^/about$ /pages/organization [R=301]
+    RewriteRule ^/members$ /pages/membershipOverview [R=301]
+    RewriteRule ^/jdap$ /pages/jdap [R=301]
+    RewriteRule ^/policies$ /pages/policies [R=301]
+    RewriteRule ^/searching$ /pages/searching [R=301]
+    RewriteRule ^/depositing$ /pages/faq#depositing [NE,R=301]
+    RewriteRule ^/using$ /pages/faq#using [NE,R=301]
+    RewriteRule ^/publicationBlackout$ /pages/publicationBlackout [R=301]
+    RewriteRule ^/dans-news$ http://wiki.datadryad.org/images/2/29/Dryad-DANS_Announcement.pdf
+    ProxyPass /dryadlab http://datadryad.org/pages/dryadlab
+    ProxyPassReverse /dryadlab http://datadryad.org/pages/dryadlab               
+
+    # Rewrites for datadryad.org metadata profile -- linked to from XML docs; don't delete!!
+    RewriteRule ^/profile/v3/dryad.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dryad.xsd [R,L]
+    RewriteRule ^/profile/v3/dc.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dc.xsd [R,L]
+    RewriteRule ^/profile/v3/dcterms.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dcterms.xsd [R,L]
+    RewriteRule ^/profile/v3/dcmitype.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/dcmitype.xsd [R,L]
+    RewriteRule ^/profile/v3/bibo.xsd$ http://dryad.googlecode.com/svn/trunk/dryad/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3/bib.xsd [R,L]
+
+    # Prevent external systems from writing to the SOLR index
+    ProxyPass /solr/search/update !
+    ProxyPassReverse /solr/search/update !
+    ProxyPass /solr/statistics/update !
+    ProxyPassReverse /solr/statistics/update !
+
+    # Rewrite "&amp;" to "&" in query strings to fix the incorrectly encoded ampersand
+    # for Journal of Fish and Wildlife
+    RewriteCond %{QUERY_STRING} ^([^\?]*)\&amp;(.*)$
+    RewriteRule ^(.*)$ $1\?%1&%2 [R]
+    		       		   
+</VirtualHost>

--- a/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
@@ -2,66 +2,66 @@ LoadModule ssl_module modules/mod_ssl.so
 
 Listen 443
 <VirtualHost *:443>
-    ServerName datadryad.org
-    ServerAlias www.datadryad.org
-    ServerAlias prod.datadryad.org
-    ErrorLog ${APACHE_LOG_DIR}/datadryad.org-error_log
-    CustomLog ${APACHE_LOG_DIR}/datadryad.org-access_log combined
-
-    AllowEncodedSlashes On
-    AcceptPathInfo On
-    AddDefaultCharset UTF-8
-    ProxyPreserveHost On
-							     
-    SSLEngine on
-
-    SSLCertificateKeyFile "/etc/apache2/certs/2017.datadryad.org.key"
-    SSLCertificateFile "/etc/apache2/certs/2017.datadryad.org.crt"
-    SSLCertificateChainFile "/etc/apache2/certs/2017.datadryad.org.ca-bundle"
-    SSLCipherSuite "ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:+LOW:!SSLv2:+EXP:+eNULL"
-    SSLCACertificateFile "/etc/apache2/certs/DataONECAChain.crt"
-    SSLProxyEngine On
-
-    RewriteEngine On
-
+  ServerName datadryad.org
+  ServerAlias www.datadryad.org
+  ServerAlias prod.datadryad.org
+  ErrorLog ${APACHE_LOG_DIR}/datadryad.org-error_log
+  CustomLog ${APACHE_LOG_DIR}/datadryad.org-access_log combined
+  
+  AllowEncodedSlashes On
+  AcceptPathInfo On
+  AddDefaultCharset UTF-8
+  ProxyPreserveHost On
+  
+  SSLEngine on
+  
+  SSLCertificateKeyFile "/etc/apache2/certs/2017.datadryad.org.key"
+  SSLCertificateFile "/etc/apache2/certs/2017.datadryad.org.crt"
+  SSLCertificateChainFile "/etc/apache2/certs/2017.datadryad.org.ca-bundle"
+  SSLCipherSuite "ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:+LOW:!SSLv2:+EXP:+eNULL"
+  SSLCACertificateFile "/etc/apache2/certs/DataONECAChain.crt"
+  SSLProxyEngine On
+  
+  RewriteEngine On
+  
 {% if dryad.is_production %}
-    # Send API requests to API server
-    RewriteRule ^/(oai.*)$ http://api.datadryad.org/$1 [R=permanent]
-    RewriteRule ^/(widget.*)$ http://api.datadryad.org/$1 [R=permanent]
-    RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
+  # Send API requests to API server
+  RewriteRule ^/(oai.*)$ http://api.datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(widget.*)$ http://api.datadryad.org/$1 [R=permanent]
+  RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
 {% endif %}
 
-    # Block DSpace security hole
-    # This redirects all vulnerable URLs to /error
-    # (which doesn't exist and throws a 404 response)
-    RewriteRule ^/+themes/.*:.*$ /error [R=permanent,L]
-
-    # General rewrites for convenient URLs
-    RewriteRule ^/docs$ /themes/Mirage/docs [R=301]
-    RewriteRule ^/submit$ /handle/10255/3/submit [R]
-    RewriteRule ^/repo(.*)$ http://www.datadryad.org$1 [P,R=301]
-    RewriteRule ^/dryadLogo.png$ /themes/Dryad/images/dryadLogo.png [R=301]
-    RewriteRule ^/about$ /pages/organization [R=301]
-    RewriteRule ^/members$ /pages/membershipOverview [R=301]
-    RewriteRule ^/jdap$ /pages/jdap [R=301]
-    RewriteRule ^/policies$ /pages/policies [R=301]
-    RewriteRule ^/searching$ /pages/searching [R=301]
-    RewriteRule ^/depositing$ /pages/faq#depositing [NE,R=301]
-    RewriteRule ^/using$ /pages/faq#using [NE,R=301]
-    RewriteRule ^/publicationBlackout$ /pages/publicationBlackout [R=301]
-    RewriteRule ^/dans-news$ http://wiki.datadryad.org/images/2/29/Dryad-DANS_Announcement.pdf
-    ProxyPass /dryadlab http://datadryad.org/pages/dryadlab
-    ProxyPassReverse /dryadlab http://datadryad.org/pages/dryadlab               
-
-    # Prevent external systems from writing to the SOLR index
-    ProxyPass /solr/search/update !
-    ProxyPassReverse /solr/search/update !
-    ProxyPass /solr/statistics/update !
-    ProxyPassReverse /solr/statistics/update !
-
-    # Rewrite "&amp;" to "&" in query strings to fix the incorrectly encoded ampersand
-    # for Journal of Fish and Wildlife
-    RewriteCond %{QUERY_STRING} ^([^\?]*)\&amp;(.*)$
-    RewriteRule ^(.*)$ $1\?%1&%2 [R]
-    		       		   
+  # Block DSpace security hole
+  # This redirects all vulnerable URLs to /error
+  # (which doesn't exist and throws a 404 response)
+  RewriteRule ^/+themes/.*:.*$ /error [R=permanent,L]
+  
+  # General rewrites for convenient URLs
+  RewriteRule ^/docs$ /themes/Mirage/docs [R=301]
+  RewriteRule ^/submit$ /handle/10255/3/submit [R]
+  RewriteRule ^/repo(.*)$ http://www.datadryad.org$1 [P,R=301]
+  RewriteRule ^/dryadLogo.png$ /themes/Dryad/images/dryadLogo.png [R=301]
+  RewriteRule ^/about$ /pages/organization [R=301]
+  RewriteRule ^/members$ /pages/membershipOverview [R=301]
+  RewriteRule ^/jdap$ /pages/jdap [R=301]
+  RewriteRule ^/policies$ /pages/policies [R=301]
+  RewriteRule ^/searching$ /pages/searching [R=301]
+  RewriteRule ^/depositing$ /pages/faq#depositing [NE,R=301]
+  RewriteRule ^/using$ /pages/faq#using [NE,R=301]
+  RewriteRule ^/publicationBlackout$ /pages/publicationBlackout [R=301]
+  RewriteRule ^/dans-news$ http://wiki.datadryad.org/images/2/29/Dryad-DANS_Announcement.pdf
+  ProxyPass /dryadlab http://datadryad.org/pages/dryadlab
+  ProxyPassReverse /dryadlab http://datadryad.org/pages/dryadlab               
+  
+  # Prevent external systems from writing to the SOLR index
+  ProxyPass /solr/search/update !
+  ProxyPassReverse /solr/search/update !
+  ProxyPass /solr/statistics/update !
+  ProxyPassReverse /solr/statistics/update !
+  
+  # Rewrite "&amp;" to "&" in query strings to fix the incorrectly encoded ampersand
+  # for Journal of Fish and Wildlife
+  RewriteCond %{QUERY_STRING} ^([^\?]*)\&amp;(.*)$
+  RewriteRule ^(.*)$ $1\?%1&%2 [R]
+  
 </VirtualHost>

--- a/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
+++ b/ansible-dryad/roles/dryad_app/templates/apache_ssl_virtualhost.j2
@@ -52,9 +52,15 @@ Listen 443
   RewriteCond %{HTTP_USER_AGENT} ^.*Ephorusbot.* [NC,OR]
   RewriteCond %{HTTP_USER_AGENT} ^.*YandexMedia.* [NC]
   RewriteRule .* - [F,L]
+
+  # remove dot and comma from the end of query strings
+  RewriteCond %{QUERY_STRING} ^(.*)[.,]$
+  RewriteRule (.*) http://datadryad.org$1?%1 [P]
   
 {% if dryad.is_production %}
   # Send API requests to API server
+  RewriteRule ^/oai$ http://api.datadryad.org/oai/request?verb=Identify [R,L]
+  RewriteRule ^/oai/$ http://api.datadryad.org/oai/request?verb=Identify [R,L]
   RewriteRule ^/(oai.*)$ http://api.datadryad.org/$1 [R=permanent]
   RewriteRule ^/(widget.*)$ http://api.datadryad.org/$1 [R=permanent]
   RewriteRule ^/(mn.*)$ http://api.datadryad.org/$1 [R=permanent]
@@ -64,6 +70,10 @@ Listen 443
   # This redirects all vulnerable URLs to /error
   # (which doesn't exist and throws a 404 response)
   RewriteRule ^/+themes/.*:.*$ /error [R=permanent,L]
+
+  # Force solr accesses to only search over archived items
+  RewriteCond %{QUERY_STRING} !DSpaceStatus:Archived
+  RewriteRule ^/solr/search/select(.*) /solr/search/select/?%{QUERY_STRING}+DSpaceStatus:Archived [R,L,NE]
   
   # General rewrites for convenient URLs
   RewriteRule ^/docs$ /themes/Mirage/docs [R=301]
@@ -87,7 +97,13 @@ Listen 443
   ProxyPassReverse /solr/search/update !
   ProxyPass /solr/statistics/update !
   ProxyPassReverse /solr/statistics/update !
-  
+
+  # Rewrites for datadryad.org metadata profile -- linked to from XML docs; don't delete!!
+  RewriteRule ^/profile/v3.1/dryad.xsd$ https://raw.github.com/datadryad/dryad-repo/dryad-master/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3.1/dryad.xsd
+  RewriteRule ^/profile/v3.1/dcterms.xsd$ https://raw.github.com/datadryad/dryad-repo/dryad-master/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3.1/dcterms.xsd
+  RewriteRule ^/profile/v3.1/bibo.xsd$ https://raw.github.com/datadryad/dryad-repo/dryad-master/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3.1/bibo.xsd
+  RewriteRule ^/profile/v3.1$ https://raw.github.com/datadryad/dryad-repo/dryad-master/dspace/modules/xmlui/src/main/webapp/themes/Dryad/meta/schema/v3.1/dryad.xsd
+
   # Rewrite "&amp;" to "&" in query strings to fix the incorrectly encoded ampersand
   # for Journal of Fish and Wildlife
   RewriteCond %{QUERY_STRING} ^([^\?]*)\&amp;(.*)$

--- a/ansible-dryad/roles/dryad_app/templates/crontab.j2
+++ b/ansible-dryad/roles/dryad_app/templates/crontab.j2
@@ -1,6 +1,11 @@
 # Backup crontab daily
 0 0 * * * /home/ubuntu/dryad-utils/backup_crontab.sh {{ dryad.instance_name }} &>/dev/null
+
 # Export database for backup purposes
+PGPORT={{ dryad.db.port }}
+PGUSER={{ dryad.db.user }}
+PGDATABASE={{ dryad.db.name }}
+DRYAD_DB_HOST={{ dryad.db.host }}
 0,30 * * * * /home/ubuntu/dryad-utils/database-export.sh -q
 
 # Export daily backup to dryad-backup at AWS

--- a/ansible-dryad/roles/dryad_app/templates/requirements.txt.j2
+++ b/ansible-dryad/roles/dryad_app/templates/requirements.txt.j2
@@ -1,0 +1,6 @@
+Pillow>=2.3.0
+wsgiref>=0.1.2
+ezid>=0.3
+sqlalchemy>=1.2.5
+awscli>=1.14.34
+boto3>=1.6.19

--- a/ansible-dryad/roles/dryad_app/templates/requirements.txt.j2
+++ b/ansible-dryad/roles/dryad_app/templates/requirements.txt.j2
@@ -4,3 +4,7 @@ ezid>=0.3
 sqlalchemy>=1.2.5
 awscli>=1.14.34
 boto3>=1.6.19
+pyopenssl
+requests[security]
+urllib3[secure]
+

--- a/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
+++ b/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
@@ -21,13 +21,13 @@
 				<default.harvester.eperson>{{ dryad.admin_email }}</default.harvester.eperson>
 
 				<!-- SOLR indexes -->
-				<default.solr.search.server>localhost/solr/search/</default.solr.search.server>
-				<default.solr.stats.server>localhost/solr/statistics</default.solr.stats.server>
-				<default.solr.dryad.server>localhost/solr/dryad</default.solr.dryad.server>
-				<default.solr.authority.server>localhost/solr/authority</default.solr.authority.server>
-				<default.solr.log.dataonemn.server>localhost/solr/dataoneMNlog</default.solr.log.dataonemn.server>
-				<default.solr.responselogging.server>localhost/solr/responselogging</default.solr.responselogging.server>
-				<default.solr.xoai.server>localhost/solr/xoai</default.solr.xoai.server>
+				<default.solr.search.server>http://localhost/solr/search/</default.solr.search.server>
+				<default.solr.stats.server>http://localhost/solr/statistics</default.solr.stats.server>
+				<default.solr.dryad.server>http://localhost/solr/dryad</default.solr.dryad.server>
+				<default.solr.authority.server>http://localhost/solr/authority</default.solr.authority.server>
+				<default.solr.log.dataonemn.server>http://localhost/solr/dataoneMNlog</default.solr.log.dataonemn.server>
+				<default.solr.responselogging.server>http://localhost/solr/responselogging</default.solr.responselogging.server>
+				<default.solr.xoai.server>http://localhost/solr/xoai</default.solr.xoai.server>
 
 				<!-- DOI -->
 				<default.doi.username>{{ dryad.doi.username }}</default.doi.username>

--- a/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
+++ b/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
@@ -21,13 +21,13 @@
 				<default.harvester.eperson>{{ dryad.admin_email }}</default.harvester.eperson>
 
 				<!-- SOLR indexes -->
-				<default.solr.search.server>{{ dryad.url }}/solr/search/</default.solr.search.server>
-				<default.solr.stats.server>{{ dryad.url }}/solr/statistics</default.solr.stats.server>
-				<default.solr.dryad.server>{{ dryad.url }}/solr/dryad</default.solr.dryad.server>
-				<default.solr.authority.server>{{ dryad.url }}/solr/authority</default.solr.authority.server>
-				<default.solr.log.dataonemn.server>{{ dryad.url }}/solr/dataoneMNlog</default.solr.log.dataonemn.server>
-				<default.solr.responselogging.server>{{ dryad.url }}/solr/responselogging</default.solr.responselogging.server>
-				<default.solr.xoai.server>{{ dryad.url }}/solr/xoai</default.solr.xoai.server>
+				<default.solr.search.server>localhost/solr/search/</default.solr.search.server>
+				<default.solr.stats.server>localhost/solr/statistics</default.solr.stats.server>
+				<default.solr.dryad.server>localhost/solr/dryad</default.solr.dryad.server>
+				<default.solr.authority.server>localhost/solr/authority</default.solr.authority.server>
+				<default.solr.log.dataonemn.server>localhost/solr/dataoneMNlog</default.solr.log.dataonemn.server>
+				<default.solr.responselogging.server>localhost/solr/responselogging</default.solr.responselogging.server>
+				<default.solr.xoai.server>localhost/solr/xoai</default.solr.xoai.server>
 
 				<!-- DOI -->
 				<default.doi.username>{{ dryad.doi.username }}</default.doi.username>

--- a/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
+++ b/ansible-dryad/roles/dryad_app/templates/settings.xml.j2
@@ -35,9 +35,9 @@
 				<default.doi.prefix>10.5061</default.doi.prefix>
 				<default.doi.testprefix>10.5072</default.doi.testprefix>
 				<default.doi.localpart.testsuffix>FK2dryad.</default.doi.localpart.testsuffix>
-				<default.doi.testmode>true</default.doi.testmode>
+				<default.doi.testmode>{% if dryad.is_production %}false{% else %}true{% endif %}</default.doi.testmode>
 				<default.dryad.localize>true</default.dryad.localize>
-				<default.doi.datacite.connected>false</default.doi.datacite.connected>
+				<default.doi.datacite.connected>{% if dryad.is_production %}true{% else %}false{% endif %}</default.doi.datacite.connected>
 				<default.doi.service>{{ dryad.url }}/doi</default.doi.service>
 
 				<!-- Email -->
@@ -46,10 +46,10 @@
 				<default.mail.server.password></default.mail.server.password>
 				<default.mail.server.disabled>{% if dryad.is_production %}false{% else %}true{% endif %}</default.mail.server.disabled>
 				<default.mail.extraproperties>mail.smtp.socketFactory.port=1025</default.mail.extraproperties>
-				<default.mail.admin>{{ dryad.admin_email }}</default.mail.admin>
-				<default.mail.help>{{ dryad.admin_email }}</default.mail.help>
-				<default.subscribe_mailinglist.recipient>{{ dryad.admin_email }}</default.subscribe_mailinglist.recipient>
-				<default.membership.recipient>{{ dryad.admin_email }}</default.membership.recipient>
+				<default.mail.admin>{% if dryad.is_production %}help@datadryad.org{% else %}{{ dryad.admin_email }}{% endif %}</default.mail.admin>
+				<default.mail.help>{% if dryad.is_production %}help@datadryad.org{% else %}{{ dryad.admin_email }}{% endif %}</default.mail.help>
+				<default.subscribe_mailinglist.recipient>{% if dryad.is_production %}help@datadryad.org{% else %}{{ dryad.admin_email }}{% endif %}</default.subscribe_mailinglist.recipient>
+				<default.membership.recipient>{% if dryad.is_production %}help@datadryad.org{% else %}{{ dryad.admin_email }}{% endif %}</default.membership.recipient>
 				<default.curator_errors.recipient>{{ dryad.curator_internal_email }}</default.curator_errors.recipient>
 				<default.automated.email.recipient>{{ dryad.automated_email }}</default.automated.email.recipient>
 
@@ -73,7 +73,7 @@
 				<paypal.vendor>{{ dryad.paypal.vendor }}</paypal.vendor>
 				<paypal.user>{{ dryad.paypal.user }}</paypal.user>
 				<paypal.pwd>{{ dryad.paypal.password }}</paypal.pwd>
-				<paypal.payflow.link>https://pilot-payflowpro.paypal.com/</paypal.payflow.link>
+				<paypal.payflow.link>{% if dryad.is_production %}https://payflowpro.paypal.com/{% else %}https://pilot-payflowpro.paypal.com/{% endif %}</paypal.payflow.link>
 				<paypal.link>https://payflowlink.paypal.com</paypal.link>
 				<paypal.partner>PayPal</paypal.partner>
 				<paypal.verbosity>HIGH</paypal.verbosity>

--- a/ansible-dryad/roles/dryad_app/templates/tomcat_stop.sh.j2
+++ b/ansible-dryad/roles/dryad_app/templates/tomcat_stop.sh.j2
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+LOGFILE="/opt/dryad/log/rsync-solr-stats-last.log"
+
 sudo pkill -o -f 'ubuntu/dryad-tomcat'
+rsync -rltgoWvO --delete /opt/dryad/solr/statistics $HOME/solrBackups >$LOGFILE

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -295,7 +295,7 @@ control_path = %(directory)s/%%h-%%r
 # By default, this option is disabled to preserve compatibility with
 # sudoers configurations that have requiretty (the default on many distros).
 #
-#pipelining = False
+pipelining = True
 
 # if True, make ansible use scp if the connection type is ssh
 # (default is sftp)


### PR DESCRIPTION
Upgrade settings for servers where is_production==true

- install an SSL virtuahost in Apache
- install SSL certificates from S3
- force most server interactions to use SSL
- force API interactions to go through the API server
- guarantee that external users cannot write to the SOLR index
- change maven settings.xml to have the "real" values for production servers, rather than using test services and sending all email to admin
- block bots and spiders that misbehave
- force SOLR to search over archived items only

To test: create a new server using the is_production flag. Verify that configurations look as expected. (It's difficult to fully test these configurations unless you actually deploy a new production server.)