### PR TITLE
Add mod_proxy_http

### DIFF
--- a/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
+++ b/ansible-dryad/roles/dryad_app/tasks/dryad_apache.yml
@@ -22,6 +22,7 @@
   with_items:
     - proxy
     - proxy_ajp
+    - proxy_http
     - rewrite
     - substitute
   become: yes


### PR DESCRIPTION
This corrects a problem where clicking on some search facets would produce an Apache error
"No protocol handler was valid for the URL"